### PR TITLE
Relax hashie dependency to allow newer versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     soda-ruby (0.2.23)
-      hashie (~> 3.4.6)
+      hashie (~> 3.4, >= 3.4.6)
       multipart-post (~> 2.0.0)
       sys-uname (~> 1.0.2)
 

--- a/soda.gemspec
+++ b/soda.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   # we depend on:
-  s.add_dependency 'hashie', '~> 3.4.6'
+  s.add_dependency 'hashie', '~> 3.4', '>= 3.4.6'
   s.add_dependency 'multipart-post', '~> 2.0.0'
   s.add_dependency 'sys-uname', '~> 1.0.2'
   s.add_development_dependency 'bundler', '~> 1.7'


### PR DESCRIPTION
Hashie uses Semantic Versioning [1], thus allowing minor updates should be safe.

[1] https://github.com/intridea/hashie/blob/9f965feb3793c45007030bfb62f9df277d647a28/CHANGELOG.md