### PR TITLE
Relax multipart-post version dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     soda-ruby (1.0.0)
       hashie (~> 3.5)
-      multipart-post (~> 2.0.0)
+      multipart-post (~> 2.0)
       sys-uname (~> 1.0.2)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     soda-ruby (1.0.0)
       hashie (~> 3.5)
       multipart-post (~> 2.0)
-      sys-uname (~> 1.0.2)
+      sys-uname (~> 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/soda.gemspec
+++ b/soda.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   # we depend on:
   s.add_dependency 'hashie', '~> 3.5'
-  s.add_dependency 'multipart-post', '~> 2.0.0'
+  s.add_dependency 'multipart-post', '~> 2.0'
   s.add_dependency 'sys-uname', '~> 1.0.2'
   s.add_development_dependency 'bundler', '~> 1.7'
   s.add_development_dependency 'rake'

--- a/soda.gemspec
+++ b/soda.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   # we depend on:
   s.add_dependency 'hashie', '~> 3.5'
   s.add_dependency 'multipart-post', '~> 2.0'
-  s.add_dependency 'sys-uname', '~> 1.0.2'
+  s.add_dependency 'sys-uname', '~> 1.0'
   s.add_development_dependency 'bundler', '~> 1.7'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'shoulda'


### PR DESCRIPTION
mulitport-post uses semantic versioning, see https://github.com/socketry/multipart-post/issues/63